### PR TITLE
Add presentation screen and grouped events by day

### DIFF
--- a/app/src/main/java/com/uns/ingeweekapp/DayEventsFragment.kt
+++ b/app/src/main/java/com/uns/ingeweekapp/DayEventsFragment.kt
@@ -1,0 +1,48 @@
+package com.uns.ingeweekapp
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.uns.ingeweekapp.databinding.FragmentDayEventsBinding
+
+class DayEventsFragment : Fragment() {
+    private var _binding: FragmentDayEventsBinding? = null
+    private val binding get() = _binding!!
+
+    private val events: List<Event>
+        get() = requireArguments().getSerializable(ARG_EVENTS) as ArrayList<Event>
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentDayEventsBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        binding.recyclerView.adapter = EventAdapter(events)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        private const val ARG_EVENTS = "events"
+
+        fun newInstance(events: ArrayList<Event>): DayEventsFragment {
+            val fragment = DayEventsFragment()
+            val args = Bundle()
+            args.putSerializable(ARG_EVENTS, events)
+            fragment.arguments = args
+            return fragment
+        }
+    }
+}

--- a/app/src/main/java/com/uns/ingeweekapp/Event.kt
+++ b/app/src/main/java/com/uns/ingeweekapp/Event.kt
@@ -1,5 +1,7 @@
 package com.uns.ingeweekapp
 
+import java.io.Serializable
+
 data class Event(
     val day: String,
     val hour: String,
@@ -7,4 +9,4 @@ data class Event(
     val topic: String,
     val speaker: String,
     val school: String
-)
+) : Serializable

--- a/app/src/main/java/com/uns/ingeweekapp/EventsFragment.kt
+++ b/app/src/main/java/com/uns/ingeweekapp/EventsFragment.kt
@@ -1,0 +1,63 @@
+package com.uns.ingeweekapp
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.google.android.material.tabs.TabLayoutMediator
+import com.uns.ingeweekapp.databinding.FragmentEventsBinding
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+class EventsFragment : Fragment() {
+    private var _binding: FragmentEventsBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentEventsBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val events = listOf(
+            Event("02-06-25", "09:00", "Plazuela UNS", "Ceremonia de Inauguración", "Autoridades UNS", "Todas"),
+            Event("03-06-25", "08:00", "Auditorio EPIE", "Hidrolisis marinos – vía enzimática", "Gabriel Sifuentes Penagos", "Agroindustrial"),
+            Event("03-06-25", "08:45", "Auditorio EPIE", "NutriAvo: Agroindustria con propósito", "Mirian Vásquez Chuquizuta", "Agroindustrial"),
+            Event("04-06-25", "09:00", "Auditorio EPIE", "Agrovoltaica", "Dr. Denis Arangurí Cayetano", "Energía"),
+            Event("04-06-25", "10:00", "Auditorio EPIE", "Técnicas nucleares para detección de Radón", "Carlos Montañez Montenegro", "Energía"),
+            Event("05-06-25", "09:00", "Capilla UNS", "Misa de Celebración", "Delegaciones", "Todas"),
+            Event("05-06-25", "10:00", "Auditorio Energía", "Ceremonia Central por la Semana", "Autoridades", "Todas"),
+            Event("06-06-25", "09:00", "Complejo Deportivo UNS", "Campeonato Interescuelas", "Delegaciones", "Todas")
+        )
+
+        val formatter = DateTimeFormatter.ofPattern("dd-MM-yy")
+        val groups = events.groupBy {
+            val date = LocalDate.parse(it.day, formatter)
+            date.dayOfWeek.getDisplayName(java.time.format.TextStyle.FULL, Locale("es"))
+        }
+
+        val days = listOf("lunes", "martes", "miércoles", "jueves", "viernes")
+        val fragments = days.map { day ->
+            DayEventsFragment.newInstance(ArrayList(groups[day] ?: emptyList()))
+        }
+
+        val adapter = EventsPagerAdapter(this, fragments)
+        binding.viewPager.adapter = adapter
+
+        TabLayoutMediator(binding.tabLayout, binding.viewPager) { tab, position ->
+            tab.text = days[position].replaceFirstChar { it.titlecase(Locale("es")) }
+        }.attach()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/uns/ingeweekapp/EventsPagerAdapter.kt
+++ b/app/src/main/java/com/uns/ingeweekapp/EventsPagerAdapter.kt
@@ -1,0 +1,12 @@
+package com.uns.ingeweekapp
+
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.adapter.FragmentStateAdapter
+
+class EventsPagerAdapter(parent: Fragment, private val fragments: List<Fragment>) :
+    FragmentStateAdapter(parent) {
+
+    override fun getItemCount(): Int = fragments.size
+
+    override fun createFragment(position: Int): Fragment = fragments[position]
+}

--- a/app/src/main/java/com/uns/ingeweekapp/MainActivity.kt
+++ b/app/src/main/java/com/uns/ingeweekapp/MainActivity.kt
@@ -25,7 +25,7 @@ class MainActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         supportFragmentManager.beginTransaction()
-            .replace(R.id.fragment_container, HomeFragment())
+            .replace(R.id.fragment_container, PresentationFragment())
             .commit()
 
         binding.themeSwitch.isChecked = AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES

--- a/app/src/main/java/com/uns/ingeweekapp/PresentationFragment.kt
+++ b/app/src/main/java/com/uns/ingeweekapp/PresentationFragment.kt
@@ -1,0 +1,37 @@
+package com.uns.ingeweekapp
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.uns.ingeweekapp.databinding.FragmentPresentationBinding
+
+class PresentationFragment : Fragment() {
+    private var _binding: FragmentPresentationBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentPresentationBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.buttonEvents.setOnClickListener {
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.fragment_container, EventsFragment())
+                .addToBackStack(null)
+                .commit()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/res/layout/fragment_day_events.xml
+++ b/app/src/main/res/layout/fragment_day_events.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:padding="16dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_events.xml
+++ b/app/src/main/res/layout/fragment_events.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tabLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/viewPager"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_presentation.xml
+++ b/app/src/main/res/layout/fragment_presentation.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/textViewInfo"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/intro_text"
+        android:textAlignment="center"
+        android:textAppearance="?attr/textAppearanceHeadlineMedium" />
+
+    <Button
+        android:id="@+id/buttonEvents"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/view_events"
+        android:layout_marginTop="24dp"
+        android:layout_gravity="center_horizontal" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,10 @@
 <resources>
     <string name="app_name">IngeWeekApp</string>
-    <!-- TODO: Remove or change this placeholder text -->
-    <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="view_events">Ver eventos</string>
+    <string name="intro_text">Bienvenidos a la Semana de Ingeniería de la UNS. Conoce los eventos y actividades de la semana.</string>
+    <string name="tab_monday">Lunes</string>
+    <string name="tab_tuesday">Martes</string>
+    <string name="tab_wednesday">Miércoles</string>
+    <string name="tab_thursday">Jueves</string>
+    <string name="tab_friday">Viernes</string>
 </resources>


### PR DESCRIPTION
## Summary
- add presentation fragment with info about the event week
- group event list by weekday and navigate with tabs
- show presentation fragment first
- make `Event` serializable
- update strings

## Testing
- `gradlew tasks` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6847bc1d865c8329afdec2ecd9b08fd3